### PR TITLE
Expose `gobernate.Router` so additional end-points can be defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,22 @@ To use the `gobernate` package to Kubernetes enable your service simply use:
 
 ```go
 import (
+	...
+	"fmt"
 	"github.com/SebastiaanPasterkamp/gobernate"
+	"net/http"
+	...
 )
 
 func main() {
 	g := gobernate.New("8080", "example", "1.0.0", "commit-sha", "build-time")
 
 	shutdown := g.Launch()
+
+	g.Router.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "Hello! Your request was processed.")
+	})
+
 	g.Ready()
 	<-shutdown
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"gobernate"
 	"gobernate/version"
+	"net/http"
 
 	"os"
 
@@ -24,6 +26,11 @@ func main() {
 	)
 
 	shutdown := g.Launch()
+
+	g.Router.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "Hello! Your request was processed.")
+	})
+
 	g.Ready()
 	<-shutdown
 }

--- a/gobernate.go
+++ b/gobernate.go
@@ -24,11 +24,12 @@ import (
 // run a golang service in Kubernetes. This code is roughly based on:
 // https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/
 type Gobernate struct {
+	// Router is the mux router, so extra end-points can be added.
+	Router   *mux.Router
 	port     string
 	info     version.Info
 	listener net.Listener
 	srv      *http.Server
-	router   *mux.Router
 	shutdown chan bool
 	isReady  *atomic.Value
 }
@@ -57,7 +58,7 @@ func New(port, name, release, commit, buildTime string) *Gobernate {
 		info:     info,
 		listener: listener,
 		srv:      srv,
-		router:   router,
+		Router:   router,
 		shutdown: shutdown,
 		isReady:  isReady,
 	}


### PR DESCRIPTION
* Expose `gobernate.Router`
* Add example to `README.md`; same for `cmd/main.go`