### PR TITLE
Fix module name to refer to the online package

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"gobernate"
-	"gobernate/version"
-	"net/http"
+	"github.com/SebastiaanPasterkamp/gobernate"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
+	"fmt"
+	"net/http"
 	"os"
 
 	log "github.com/sirupsen/logrus"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gobernate
+module github.com/SebastiaanPasterkamp/gobernate
 
 go 1.13
 
@@ -7,3 +7,5 @@ require (
 	github.com/prometheus/client_golang v1.8.0
 	github.com/sirupsen/logrus v1.7.0
 )
+
+replace github.com/SebastiaanPasterkamp/gobernate => ./

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -357,6 +358,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -409,6 +411,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/gobernate.go
+++ b/gobernate.go
@@ -5,15 +5,15 @@
 package gobernate
 
 import (
-	"gobernate/handlers"
-	"gobernate/version"
-	"net"
-	"sync/atomic"
+	"github.com/SebastiaanPasterkamp/gobernate/handlers"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
 	"context"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/gorilla/mux"

--- a/gobernate_test.go
+++ b/gobernate_test.go
@@ -1,7 +1,7 @@
 package gobernate_test
 
 import (
-	"gobernate"
+	"github.com/SebastiaanPasterkamp/gobernate"
 
 	"net/http"
 	"testing"

--- a/handlers/router.go
+++ b/handlers/router.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	mw "gobernate/middleware"
-	"gobernate/version"
+	mw "github.com/SebastiaanPasterkamp/gobernate/middleware"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
 	"sync/atomic"
 

--- a/handlers/router_test.go
+++ b/handlers/router_test.go
@@ -1,12 +1,12 @@
 package handlers_test
 
 import (
-	"gobernate/handlers"
-	"gobernate/version"
-	"sync/atomic"
+	"github.com/SebastiaanPasterkamp/gobernate/handlers"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 

--- a/handlers/version.go
+++ b/handlers/version.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"gobernate/version"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
 	"encoding/json"
 	"net/http"

--- a/handlers/version_test.go
+++ b/handlers/version_test.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"gobernate/version"
+	"github.com/SebastiaanPasterkamp/gobernate/version"
 
 	"encoding/json"
 	"net/http"

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -1,7 +1,7 @@
 package middleware_test
 
 import (
-	mw "gobernate/middleware"
+	mw "github.com/SebastiaanPasterkamp/gobernate/middleware"
 
 	"net/http"
 	"net/http/httptest"

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -1,7 +1,7 @@
 package middleware_test
 
 import (
-	mw "gobernate/middleware"
+	mw "github.com/SebastiaanPasterkamp/gobernate/middleware"
 
 	"net/http"
 	"net/http/httptest"


### PR DESCRIPTION
Package can now be included as:

```go
import "github.com/SebastiaanPasterkamp/gobernate"
```