### PR TITLE
CI uses kubernetes pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-type: docker
+type: kubernetes
 name: Test
 
 platform:
@@ -10,11 +10,6 @@ platform:
 steps:
   - name: unit-test
     image: golang:1.15-alpine
-    volumes:
-      - name: apk-cache
-        path: /etc/apk/cache
-      - name: golang-cache
-        path: /root/go/pkg/mod/cache
     commands:
       - |-
         apk add \
@@ -34,62 +29,37 @@ steps:
     depends_on:
       - unit-test
 
-  - name: prep-build-test
-    image: golang:1.15-alpine
-    when:
-      event:
-        exclude:
-        - tag
-    commands:
-      - apk add git
-      - git fetch --tags
-      - echo 'GIT_TAG='$(git describe --tags || echo 'initial') >> .env
-
   - name: build-test
-    image: docker
-    volumes:
-      - name: socket
-        path: /var/run/docker.sock
+    image: plugins/docker
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: docker-registry.pikube.dev/gobernate
+      tags:
+        - unstable
+        - $${DRONE_BRANCH}
     when:
       event:
         exclude:
         - tag
-    commands:
-      - . .env
-      - |-
-        docker build \
-          -t gobernate:unstable \
-          -t gobernate:$${GIT_TAG} .
-    depends_on:
-      - prep-build-test
 
   - name: build-production
-    image: docker
-    volumes:
-      - name: socket
-        path: /var/run/docker.sock
+    image: plugins/docker
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: docker-registry.pikube.dev/gobernate
+      auto_tag: true
+      mirror: docker-mirror.pikube.dev
     when:
       event:
       - tag
-    commands:
-      - |-
-        docker build \
-          -t gobernate:latest \
-          -t gobernate:${DRONE_TAG} .
-
-volumes:
-  - name: apk-cache
-    host:
-      path: /var/cache/drone/apk
-  - name: golang-cache
-    host:
-      path: /var/cache/drone/golang
-  - name: socket
-    host:
-      path: /var/run/docker.sock
-
 ---
 kind: signature
-hmac: 11371e40753e6ee056d779fde5d53b9253ed648a23eb1409df42fbcae020c120
+hmac: 932f6229d27b4cb4e0941721196c7062fd02ca9fcc4a614f92b1c7cfe9a6bafc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,23 +9,16 @@ platform:
 
 steps:
   - name: unit-test
-    image: golang:1.15-alpine
+    image: golang:1.15-stretch
     commands:
-      - |-
-        apk add \
-            build-base \
-            gcc
-      - |-
-        go test \
-          -coverprofile cover.out \
-          ./...
+      - apt-get update
+      - apt-get install -y git build-essential
+      - go test -coverprofile cover.out ./...
 
   - name: coverage
-    image: golang:1.15-alpine
+    image: golang:1.15-stretch
     commands:
-      - |-
-        go tool cover \
-          -func cover.out
+      - go tool cover -func cover.out
     depends_on:
       - unit-test
 
@@ -71,6 +64,6 @@ steps:
 
 ---
 kind: signature
-hmac: f5398e36124f30a7ce737343add86bc9a29fd1cab54b03c4d05a976de62925ac
+hmac: ca8602a5ced1b7dfdfaa2ca6ed6436923bad083bdc958f52cb1164a872e131d2
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,10 +25,10 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: Image
+name: Image Staging
 
 depends_on:
-  - Test
+- Test
 
 platform:
   os: linux
@@ -38,32 +38,42 @@ steps:
   - name: build-test
     image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      registry: docker-registry.pikube.dev:31443
+      registry: docker-registry-service.docker-registry:5000
       repo: gobernate
       tags:
       - ${DRONE_BRANCH}
       - unstable
       cache: true
       insecure_registry: true
-    when:
-      event:
-        exclude:
-          - tag
 
+---
+kind: pipeline
+type: kubernetes
+name: Image Production
+
+trigger:
+  event:
+  - tag
+
+depends_on:
+- Image Staging
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
   - name: build-production
     image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      registry: docker-registry.pikube.dev:31443
+      registry: docker-registry-service.docker-registry:5000
       repo: gobernate
       auto_tag: true
       cache: true
       insecure_registry: true
-    when:
-      event:
-        - tag
 
 ---
 kind: signature
-hmac: ca8602a5ced1b7dfdfaa2ca6ed6436923bad083bdc958f52cb1164a872e131d2
+hmac: 063ed263364115df29f474a26e5d4fe14da2fa1f949d28d0e22523828a6e404f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,37 +29,48 @@ steps:
     depends_on:
       - unit-test
 
+---
+kind: pipeline
+type: kubernetes
+name: Image
+
+depends_on:
+  - Test
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
   - name: build-test
-    image: plugins/docker
+    image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: docker-registry.pikube.dev/gobernate
+      registry: docker-registry.pikube.dev:31443
+      repo: gobernate
       tags:
-        - unstable
-        - $${DRONE_BRANCH}
+      - ${DRONE_BRANCH}
+      - unstable
+      cache: true
+      insecure_registry: true
     when:
       event:
         exclude:
-        - tag
+          - tag
 
   - name: build-production
-    image: plugins/docker
+    image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: docker-registry.pikube.dev/gobernate
+      registry: docker-registry.pikube.dev:31443
+      repo: gobernate
       auto_tag: true
-      mirror: docker-mirror.pikube.dev
+      cache: true
+      insecure_registry: true
     when:
       event:
-      - tag
+        - tag
+
 ---
 kind: signature
-hmac: 932f6229d27b4cb4e0941721196c7062fd02ca9fcc4a614f92b1c7cfe9a6bafc
+hmac: f5398e36124f30a7ce737343add86bc9a29fd1cab54b03c4d05a976de62925ac
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # See https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324
-FROM golang:1.15-alpine AS builder
+FROM golang:1.15-stretch AS builder
 
 # Git is used for dependencies
-RUN apk update \
-    && apk add \
-        --no-cache \
+RUN apt-get update \
+    && apt-get install -y \
         git \
         ca-certificates
 
@@ -24,9 +23,8 @@ WORKDIR $GOPATH/src/gobernate/
 
 COPY go.mod go.sum ./
 
-RUN apk add \
-      build-base \
-      gcc \
+RUN apt-get install -y \
+      build-essential \
     && go mod download \
     && go mod verify
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dndrone.nl.eu.org/api/badges/SebastiaanPasterkamp/gobernate/status.svg)](https://dndrone.nl.eu.org/SebastiaanPasterkamp/gobernate)
+
 Package `gobernate` provides an easy HTTP Handler containing all end-points
 required to run a golang service in Kubernetes. This code is roughly based on:
 https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/
@@ -6,11 +8,10 @@ To use the `gobernate` package to Kubernetes enable your service simply use:
 
 ```go
 import (
-	...
 	"fmt"
-	"github.com/SebastiaanPasterkamp/gobernate"
 	"net/http"
-	...
+
+	"github.com/SebastiaanPasterkamp/gobernate"
 )
 
 func main() {
@@ -35,3 +36,8 @@ The `gobernate` http service provides:
   called before signaling `http.StatusOK`, and will report if the service is
   already shutting down.
 * `GET /metrics` to return Prometheus formatted metric data.
+
+# To do
+* Option to add a custom readiness callback.
+* Constructor with configuration struct.
+* Built in OpenTelemetry support.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.8.0
 	github.com/sirupsen/logrus v1.7.0
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )
 
 replace github.com/SebastiaanPasterkamp/gobernate => ./

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
* The drone.io CI pipeline now uses the Kubernetes platform.
* The base image (for building the binary) has switched from `alpine` to `stretch`. The final image still uses `scratch`.